### PR TITLE
Fix asset imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,35 @@
 /* jshint node: true */
 'use strict';
 
-const path = require('path');
-
 module.exports = {
   name: 'ember-leaflet-draw',
 
   included: function(app) {
     this._super.included.apply(this, arguments);
+    
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    }
 
-    app.import(path.join(app.bowerDirectory, 'leaflet-draw', 'dist', 'leaflet.draw.js'));
-    app.import(path.join(app.bowerDirectory, 'leaflet-draw', 'dist', 'leaflet.draw.css'));
+    // Otherwise, we'll use this implementation borrowed from the _findHost()
+    // method in ember-cli.
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    var current = this;
+    do {
+     app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+    
+    var baseDir = app.bowerDirectory + '/leaflet-draw/dist/';
+
+    app.import(baseDir + 'leaflet.draw.js');
+    app.import(baseDir + 'leaflet.draw.css');
 
     var imagesDestDir = '/assets/images';
-    app.import(path.join(app.bowerDirectory, 'leaflet-draw', 'dist', 'images/spritesheet-2x.png'), { destDir: imagesDestDir });
-    app.import(path.join(app.bowerDirectory, 'leaflet-draw', 'dist', 'images/spritesheet.png'), { destDir: imagesDestDir });
-    app.import(path.join(app.bowerDirectory, 'leaflet-draw', 'dist', 'images/spritesheet.svg'), { destDir: imagesDestDir });
+    app.import(baseDir + 'images/spritesheet-2x.png', { destDir: imagesDestDir });
+    app.import(baseDir + 'images/spritesheet.png', { destDir: imagesDestDir });
+    app.import(baseDir + 'images/spritesheet.svg', { destDir: imagesDestDir });
   }
 };


### PR DESCRIPTION
- This makes it work in nested addons and engines
- Also makes it work if on Windows (`app.import` doesn't expect OS separators, so `path.join` breaks it on Windows)