### PR TITLE
Get leaflet-draw from NPM instead of Bower

### DIFF
--- a/blueprints/ember-leaflet-draw/index.js
+++ b/blueprints/ember-leaflet-draw/index.js
@@ -1,10 +1,10 @@
-/*jshint node:true*/
-module.exports = {
-  description: 'add leaflet-draw assets, using bower',
-
-  normalizeEntityName: function() {}, // no-op since we're just adding dependencies
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('leaflet-draw', '~0.4.9');
-  }
-};
+// /*jshint node:true*/
+// module.exports = {
+//   description: 'add leaflet-draw assets, using bower',
+//
+//   normalizeEntityName: function() {}, // no-op since we're just adding dependencies
+//
+//   afterInstall: function() {
+//     return this.addBowerPackageToProject('leaflet-draw', '~0.4.9');
+//   }
+// };

--- a/blueprints/ember-leaflet-draw/index.js
+++ b/blueprints/ember-leaflet-draw/index.js
@@ -1,10 +1,10 @@
-// /*jshint node:true*/
-// module.exports = {
-//   description: 'add leaflet-draw assets, using bower',
-//
-//   normalizeEntityName: function() {}, // no-op since we're just adding dependencies
-//
-//   afterInstall: function() {
-//     return this.addBowerPackageToProject('leaflet-draw', '~0.4.9');
-//   }
-// };
+/*jshint node:true*/
+module.exports = {
+  description: 'add leaflet-draw assets, using npm',
+
+  normalizeEntityName: function() {}, // no-op since we're just adding dependencies
+
+  afterInstall: function() {
+    return this.addPackageToProject('leaflet-draw', '~0.4.9');
+  }
+};

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,6 @@
   "dependencies": {
     "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
-    "leaflet": "~1.0.3",
-    "leaflet-draw": "~0.4.9",
     "semantic-ui": "^2.2.7",
     "font-awesome": "~4.5.0"
   }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,20 @@
 /* jshint node: true */
 'use strict';
+const resolve = require('resolve');
+const path = require('path');
+const Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-leaflet-draw',
 
+  treeForVendor: function() {
+    let dist = path.join(this.pathBase('leaflet-draw'), 'dist');
+    return new Funnel(dist, { destDir: 'leaflet-draw' });
+  },
+
   included: function(app) {
     this._super.included.apply(this, arguments);
-    
+
     // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
     // use that.
     if (typeof this._findHost === 'function') {
@@ -21,8 +29,8 @@ module.exports = {
     do {
      app = current.app || app;
     } while (current.parent.parent && (current = current.parent));
-    
-    var baseDir = app.bowerDirectory + '/leaflet-draw/dist/';
+
+    var baseDir = 'vendor/leaflet-draw/';
 
     app.import(baseDir + 'leaflet.draw.js');
     app.import(baseDir + 'leaflet.draw.css');
@@ -31,5 +39,9 @@ module.exports = {
     app.import(baseDir + 'images/spritesheet-2x.png', { destDir: imagesDestDir });
     app.import(baseDir + 'images/spritesheet.png', { destDir: imagesDestDir });
     app.import(baseDir + 'images/spritesheet.svg', { destDir: imagesDestDir });
+  },
+
+  pathBase: function(packageName) {
+    return path.dirname(resolve.sync(packageName + '/package.json', { basedir: __dirname }));
   }
 };

--- a/package.json
+++ b/package.json
@@ -56,10 +56,13 @@
     "point"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-composability-tools": "0.0.7",
-    "ember-invoke-action": "^1.4.0"
+    "ember-invoke-action": "^1.4.0",
+    "leaflet": "^1.0.3",
+    "leaflet-draw": "~0.4.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
The ember-leaflet addon recently switched to getting leaflet from NPM instead of Bower (https://github.com/miguelcobain/ember-leaflet/pull/145), which is the direction most Ember addons seem to be going as more people drop Bower (in fact Bower has itself marked as deprecated on NPM and directs people to Yarn and Webpack).

This PR replicates the solution implemented for ember-leaflet. It doesn't add any new dependencies, but it does make the dependence on broccoli-funnel explicit instead of transitive (ember-cli depends on it).