### PR TITLE
Initial geoJSON features on map

### DIFF
--- a/addon/components/draw-control.js
+++ b/addon/components/draw-control.js
@@ -50,6 +50,16 @@ export default BaseLayer.extend({
     if(this.get('showDrawingLayer')) {
       drawingLayerGroup = new this.L.FeatureGroup();
       const map = this.get('parentComponent._layer');
+      
+      // If supplied, draw initial features onto editable feature group
+			let initialFeatures = this.get('initialFeatures');	// L.geoJson()
+			if(initialFeatures) {
+				initialFeatures.eachLayer(function(layer) {
+					this._applyOptionsToLayer(layer);
+					layer.addTo(drawingLayerGroup);
+				}, this);
+			}
+      
       drawingLayerGroup.addTo(map);
     }
     return drawingLayerGroup;
@@ -89,6 +99,16 @@ export default BaseLayer.extend({
       }
     }
   },
+  
+  // Helper method to set layer.options to draw config
+	_applyOptionsToLayer(layer) {
+		let shapeOptions = {};
+		// Currently just uses options for polygon, since we can't tell what shape it is (or can we?)
+    shapeOptions = this.get('draw.polygon.shapeOptions');
+
+		let drawConfig = Ember.$.extend({}, layer.options, shapeOptions);
+		layer.options = drawConfig;
+	},
 
   _addEventListeners() {
     this._eventHandlers = {};

--- a/addon/components/draw-control.js
+++ b/addon/components/draw-control.js
@@ -103,8 +103,8 @@ export default BaseLayer.extend({
   // Helper method to set layer.options to draw config
 	_applyOptionsToLayer(layer) {
 		let shapeOptions = {};
-		// Currently just uses options for polygon, since we can't tell what shape it is (or can we?)
-    shapeOptions = this.get('draw.polygon.shapeOptions');
+		// Currently just uses its own options set, since we can't tell what shape it is (or can we?)
+    shapeOptions = this.get('draw.initial.shapeOptions');
 
 		let drawConfig = Ember.$.extend({}, layer.options, shapeOptions);
 		layer.options = drawConfig;


### PR DESCRIPTION
To draw some initial shapes on the map, pass in an L.geoJSON object like so;
```handlebars
{{draw-control initialFeatures=someGeoJSON draw=drawConfig}}
```

```javascript
someGeoJSON: computed(function() {
  return L.geoJson([this.get('feature1'),this.get('feature2')]);
}),
feature1: {
  "type": "Feature",
  "properties": {},
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      [
        [-104.998741, 39.741796],	// LNG, LAT
        [-104.998741, 39.7447],
        [-104.99226, 39.7447],
        [-104.99226, 39.741796],
        [-104.998741, 39.741796]
      ]
    ]
  }
},
feature2: {
  "type": "Feature",
  "properties": {},
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      [
        [-105.998741, 39.541796],	// LNG, LAT
        [-105.998741, 39.5447],
        [-105.99226, 39.5447],
        [-105.99226, 39.541796],
        [-105.998741, 39.541796]
      ]
    ]
  }
}
```

These shapes are editable/deletable just like any other shape that the user draws.

To set the shapeOptions of the initial shapes, there is a new key in the draw config object.
```javascript
drawConfig: {
  marker: false,
  circle: false,
  polyline: false,
  circlemarker: false,
  polygon: {
    shapeOptions: {
      color: '#00FF0F'	// green
    }
  },
  rectangle: {
    shapeOptions: {
      color: '#0FFFF0'	// cyan
    }
  },
  initial: {
    shapeOptions: {
      color: '#0000FF'	// blue
    }
  }
},
```

There are no tests written for this yet because I wasn't sure if this was the best approach.