### PR TITLE
Observe & update draw options

### DIFF
--- a/addon/components/draw-control.js
+++ b/addon/components/draw-control.js
@@ -50,6 +50,16 @@ export default BaseLayer.extend({
     if(this.get('showDrawingLayer')) {
       drawingLayerGroup = new this.L.FeatureGroup();
       const map = this.get('parentComponent._layer');
+      
+      // If supplied, draw initial features onto editable feature group
+			let initialFeatures = this.get('initialFeatures');	// L.geoJson()
+			if(initialFeatures) {
+				initialFeatures.eachLayer(function(layer) {
+					this._applyOptionsToLayer(layer);
+					layer.addTo(drawingLayerGroup);
+				}, this);
+			}
+      
       drawingLayerGroup.addTo(map);
     }
     return drawingLayerGroup;
@@ -89,6 +99,16 @@ export default BaseLayer.extend({
       }
     }
   },
+  
+  // Helper method to set layer.options to draw config
+	_applyOptionsToLayer(layer) {
+		let shapeOptions = {};
+		// Currently just uses options for polygon, since we can't tell what shape it is (or can we?)
+    shapeOptions = this.get('draw.polygon.shapeOptions');
+
+		let drawConfig = Ember.$.extend({}, layer.options, shapeOptions);
+		layer.options = drawConfig;
+	},
 
   _addEventListeners() {
     this._eventHandlers = {};

--- a/addon/components/draw-control.js
+++ b/addon/components/draw-control.js
@@ -170,7 +170,7 @@ export default BaseLayer.extend({
 	_addObservers() {
 		this._argObservers = {};
 
-		this._argObservers['draw'] = this._drawChanged();
+		this._argObservers['draw'] = function() { this._drawChanged(); };
 		this.addObserver('draw', this, this._argObservers['draw']);
 	},
 

--- a/addon/components/draw-control.js
+++ b/addon/components/draw-control.js
@@ -103,8 +103,8 @@ export default BaseLayer.extend({
   // Helper method to set layer.options to draw config
 	_applyOptionsToLayer(layer) {
 		let shapeOptions = {};
-		// Currently just uses options for polygon, since we can't tell what shape it is (or can we?)
-    shapeOptions = this.get('draw.polygon.shapeOptions');
+		// Currently just uses its own options set, since we can't tell what shape it is (or can we?)
+    shapeOptions = this.get('draw.initial.shapeOptions');
 
 		let drawConfig = Ember.$.extend({}, layer.options, shapeOptions);
 		layer.options = drawConfig;


### PR DESCRIPTION
This PR branches off of the 'initial-features' PR I also made here https://github.com/StevenHeinrich/ember-leaflet-draw/pull/9

I needed a way to change the options for new shapes that are drawn (specifically, I needed to change the colour). This is a first attempt at getting the 'draw' arg to be observed so that new shapeOptions can be applied, using the leaflet-draw method `setDrawingOptions`. Seems to work, I have only tested changing the colour though.

I also included a commented out section in `_drawChanged()` which will also apply the new draw shapeOptions to existing objects that were previously drawn. There are some caveats to that code;
* Not sure how to tell what shape a previously drawn object is (they're all instances of L.Polygon..), so it just gets the `draw.initial.shapeOptions` applied to it, this is probably not desired
* Users may not want existing shapes to be updated with new draw options - perhaps existing shapes should be updated in some other way? Or put this functionality behind an arg to the component called something like `updateExistingShapes=true` ?

My leaflet skills aren't the best and I've only been using this addon for a day so please chime in if you know any improvements that can be made (or just go ahead and commit them!)